### PR TITLE
Do not include trait twice

### DIFF
--- a/Classes/Controller/ExtensionController.php
+++ b/Classes/Controller/ExtensionController.php
@@ -22,7 +22,6 @@ class ExtensionController extends AbstractController
     use FileServiceTrait;
     use \Datamints\DatamintsLocallangBuilder\Domain\Repository\Traits\ExtensionRepositoryTrait;
     use \Datamints\DatamintsLocallangBuilder\Services\Traits\CachesServiceTrait;
-    use \Datamints\DatamintsLocallangBuilder\Domain\Repository\Traits\ExtensionRepositoryTrait;
 
     /**
      * Using JSon-View-Output indead of html-Templates


### PR DESCRIPTION
Fatal error: Trait method injectExtensionRepository has not been applied, because there are collisions with other trait methods on Datamints\DatamintsLocallangBuilder\Controller\ExtensionController in /typo3conf/ext/datamints_locallang_builder/Classes/Controller/ExtensionController.php on line 19