### PR TITLE
[DOCS] Fix formatting

### DIFF
--- a/Documentation/Developer/Index.rst
+++ b/Documentation/Developer/Index.rst
@@ -6,10 +6,12 @@
 Developer Corner
 ================
 
-- If you need to modify the templates or other stuff, you can initialize the git submodule in /Resources/Public/VueSources.
+-  If you need to modify the templates or other stuff, you can initialize the git submodule in /Resources/Public/VueSources.
+
    -  The Submodule is fetched from https://github.com/datamintsGmbH/datamints_locallang_builder_vue
-- Then you have to run "npm install" to load all dependencies.
-- To build the "VueGenerated" files you have to run a Node-Script, see /Resources/Public/VueSources/package.json for possible script-names, e.g. "npm run watchProd"
+
+-  Then you have to run "npm install" to load all dependencies.
+-  To build the "VueGenerated" files you have to run a Node-Script, see /Resources/Public/VueSources/package.json for possible script-names, e.g. "npm run watchProd"
 
 Please be aware: See "datamints_locallang_builder/LICENSE.txt" before copying or using the 3rd party libraries included in this submodule. Some of them are licenced only for this purpose.
 


### PR DESCRIPTION
In reStructuredText, bullet list must be preceded and followed by
a newline. This is also the case if bullet lists are nested. A
newline must be inserted between the levels.

----

Not part of commit. 

Tips

* bullet lists: https://docs.typo3.org/m/typo3/docs-how-to-document/main/en-us/WritingReST/CommonPitfalls/Lists.html

Additionally, I might consider other formatting, e.g. the styled 1-2-3 lists, see https://docs.typo3.org/m/typo3/docs-how-to-document/main/en-us/WritingReST/BignumLists.html