### PR TITLE
[DOCS] Use link to rendered documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A TYPO3 extension for adding, modifying and auto-translating content of extensio
 Links:
 
 - [TER](https://typo3.org/extensions/repository/view/datamints_locallang_builder)
-- [Documentation](https://docs.typo3.org/p/datamints/locallang_builder/master/en-us/)
+- [Documentation](https://docs.typo3.org/p/datamints/locallang_builder/main/en-us/)
 - [Contact](mailto:m.weisgerber@datamints.com)
 
 Features:
@@ -22,7 +22,7 @@ Features:
 Usage and installation:
 ---------
 
-- See documentation: https://github.com/datamintsGmbH/datamints_locallang_builder/tree/master/Documentation
+- See documentation: https://docs.typo3.org/p/datamints/locallang_builder/main/en-us/
 
 Screenshots
 ---------


### PR DESCRIPTION
Use the same link to the rendered documentation as above.

Additionally, use "main" branch name instead of "master".
All URLs with master are now redirected to main on
docs.typo3.org - even for repos with default branch master.