### PR TITLE
[BUGFIX] Save correct extension path

### DIFF
--- a/Classes/Service/FileService.php
+++ b/Classes/Service/FileService.php
@@ -29,7 +29,7 @@ class FileService extends AbstractService
 			$extensionsObject[] = [
 				'key' => $extensionKey,
 				'local' => strpos(ExtensionManagementUtility::extPath($extensionKey), Environment::getExtensionsPath()) > -1,
-				'path' => PathUtility::sanitizeTrailingSeparator('typo3conf/ext/' . $extensionKey),
+				'path' => PathUtility::sanitizeTrailingSeparator('EXT:' . $extensionKey),
 			];
 		}
 		return $extensionsObject;


### PR DESCRIPTION
Since TYPO3 v12 no longer uses `typo3conf/ext` as extension directory, but the default composer `vendor` directory, the extension path should be calculated by TYPO3 by using `EXT:...`.